### PR TITLE
GB-LND to E40000003 and added supported regions for WSS.

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -453,7 +453,7 @@ mrc-ide-covid-sim:
     FI: []
     FR: []
     GB:
-      - GB-LND
+      - E40000003
     GI: []
     GR: []
     HR: []
@@ -621,4 +621,14 @@ wss:
   supportedRegions:
     GB:
       - GB-ENG
+      - GB-SCT
+      - GB-WLS
+      - GB-NIR
+      - E40000003
+      - E40000005
+      - E40000006
+      - E40000007
+      - E40000008
+      - E40000009
+      - E40000010
 


### PR DESCRIPTION
Changes to the `models.yml` file:

* `GB-LND` -> E40000003 for CovidSim
* Added regions supported by WSS

