### PR TITLE
Removed command --default-authentication-plugin=mysql_native_password in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The "advanced" mode is for maintainers only—it requires access to some shared 
 
 1. [Docker][docker] (v19.03).
    - This repository assumes that your [user has been configured to manage Docker](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
+   - **_NOTE_**: This does not work out of the box with [colima](https://github.com/abiosoft/colima). Additional configuration may be required.
 1. [Docker Compose][docker-compose] (v1.22).
 1. Node.js (v14.15) / npm (v6.14), either installed [directly][npm] or using [nvm][nvm].
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.7'
 
 services:
   db:
-    image: mysql:8
+    image: mysql:8.4
+    command: --mysql-native-password=ON
     environment:
       MYSQL_USER: user
       MYSQL_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.7'
 services:
   db:
     image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_USER: user
       MYSQL_PASSWORD: password


### PR DESCRIPTION
Solves #59 
Issue seems related to `default_authentication_plugin` being deprecated in versions 8.4+ as per the [updates](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html). If it is necessary to keep this line, it would be a better idea to fix the image version to 8.0 instead. 